### PR TITLE
Cleanup circuits

### DIFF
--- a/circuits/account/Nargo.toml
+++ b/circuits/account/Nargo.toml
@@ -4,3 +4,4 @@ compiler_version = "0.1"
 
 [dependencies]
 utils = { path = "../utils_lib" }
+notes = { path = "../notes" }

--- a/circuits/account/src/main.nr
+++ b/circuits/account/src/main.nr
@@ -1,5 +1,6 @@
 use dep::std;
 use dep::utils;
+use dep::notes;
 
 fn main(
   data_tree_root: Field,
@@ -25,22 +26,9 @@ fn main(
     // 1: create: create == 1 && migrate == 0
     // 2: update = create == 0 && migrate == 0
     // 3: migrate = create == 0 && migrate == 1
-
-    let output_note_1_commitment = std::hash::pedersen([
-        alias_hash, 
-        new_account_public_key[0],
-        new_account_public_key[1],
-        spending_public_key_1[0],
-        spending_public_key_1[1]
-    ])[0];
-
-    let output_note_2_commitment = std::hash::pedersen([
-        alias_hash,
-        new_account_public_key[0],
-        new_account_public_key[1],
-        spending_public_key_2[0],
-        spending_public_key_2[1]
-    ])[0];
+    
+    let output_note_1 = notes::account::AccountNote::new(alias_hash, new_account_public_key, spending_public_key_1);
+    let output_note_2 = notes::account::AccountNote::new(alias_hash, new_account_public_key, spending_public_key_2);
 
     // @dev unlimited zero-valued nullifiers are permitted by the rollup circuit (e.g. if create == 0).
     let mut nullifier_1 = 0;
@@ -79,7 +67,7 @@ fn main(
         ]
     )[0];
     constrain message != 0;
-    
+
     let message_byte_array = std::to_bytes(message, 31);
     let sig_res = std::schnorr::verify_signature(signer[0], signer[1], signature, message_byte_array);
     constrain sig_res == 1;
@@ -117,8 +105,8 @@ fn main(
 
     [
         proof_id, 
-        output_note_1_commitment, 
-        output_note_2_commitment,
+        output_note_1.commitment, 
+        output_note_2.commitment,
         nullifier_1,
         nullifier_2,
         public_value,

--- a/circuits/claim/src/main.nr
+++ b/circuits/claim/src/main.nr
@@ -31,33 +31,19 @@ fn main(
     let second_input_in_use = claim_note_data.bridge_call_data_local.config.second_input_in_use;
     let second_output_in_use = claim_note_data.bridge_call_data_local.config.second_output_in_use;
 
-    constrain claim_note.deposit_value != 0;
-
-    // NOTE: Fields cannot be compared as these inputs are specified as Noir's largest integer type when using the aztec_backend: u126
-    constrain (claim_note.deposit_value < defi_interaction_note.total_input_value) | (claim_note.deposit_value == defi_interaction_note.total_input_value);
-    constrain (defi_interaction_note.total_input_value - claim_note.deposit_value) >= 0;
-
-    constrain (defi_interaction_note.total_output_value_a - output_value_a) >= 0;
-
-    constrain (defi_interaction_note.total_output_value_b - output_value_b) >= 0;
-
-    // Ratio checks.
-    // Note, these ratio_checks also guarantee:
-    //   defi_interaction_note.total_input_value != 0
-    //   defi_interaction_note.total_output_value_a != 0 (unless output_value_a == 0)
-    //   defi_interaction_note.total_output_value_b != 0 (unless output_value_b == 0)
-    constrain ((claim_note.deposit_value / defi_interaction_note.total_input_value) as Field) == (output_value_a / defi_interaction_note.total_output_value_a);
-    
-    constrain ((claim_note.deposit_value / defi_interaction_note.total_input_value) as Field) == (output_value_b / defi_interaction_note.total_output_value_b);
+    validate_notes(
+        claim_note,
+        defi_interaction_note,
+        output_value_a,
+        output_value_b
+    );
 
     let nullifier1 = notes::claim::compute_nullifier(claim_note.commitment);
-
     let nullifier2 = notes::defi_interaction::compute_nullifier(defi_interaction_note.commitment, claim_note.commitment);
 
     // Compute output notes.
     // const auto virtual_note_flag = suint_ct(uint256_t(1) << (MAX_NUM_ASSETS_BIT_LENGTH - 1));
     let virtual_note_flag = ((1 as u64) << 29) as Field;
-    // let virtual_note_flag = 1;
 
     // If the defi interaction was unsuccessful, refund the original defi_deposit_value (which was denominated in
     // bridge input_asset_id_a) via output note 1.
@@ -75,15 +61,12 @@ fn main(
         output_asset_id_1 = output_asset_id_1_if_success;
     }
 
-    // NOTE: Commitment computation from C++
-    // output_note_commitment1 = circuit::value::complete_partial_commitment(
-    //     claim_note.value_note_partial_commitment, output_value_1, output_asset_id_1, nullifier1);
     let output_note_commitment1 = std::hash::pedersen(
         [
             claim_note.value_note_partial_commitment,
             output_value_1,
             output_asset_id_1,
-            nullifier1, // TODO add a VALUE_NOTE_COMMITMENT generator index
+            nullifier1, // TODO add a VALUE_NOTE_COMMITMENT generator index for complete_partial_commitment
         ]
     )[0];
 
@@ -119,10 +102,14 @@ fn main(
 
     output_note_commitment2 = output_note_commitment2 * (output_note_2_exists as Field);
 
+    // Check claim note and interaction note are related.
     // TODO: check which is less constraints, converting to a field with bit shifts or checking each field individually
     constrain claim_note.bridge_call_data.to_field() == defi_interaction_note.bridge_call_data.to_field();
     constrain claim_note.defi_interaction_nonce == defi_interaction_note.interaction_nonce;
 
+    // Existence checks
+
+    // Check claim note exists:
     let claim_exists = std::merkle::check_membership(
         data_root,
         claim_note.commitment,
@@ -131,6 +118,7 @@ fn main(
     );
     constrain claim_exists == 1;
 
+    // Check defi interaction note exists:
     let din_exists = std::merkle::check_membership(
         data_root,
         defi_interaction_note.commitment,
@@ -164,4 +152,39 @@ fn main(
         backward_link,
         allow_chain
     ]
+}
+
+fn validate_notes(
+    claim_note: notes::claim::ClaimNote,
+    defi_interaction_note: notes::defi_interaction::Note,
+    output_value_a: Field,
+    output_value_b: Field,
+) {
+    // Don't support zero deposits (because they're illogical):
+    constrain claim_note.deposit_value != 0;
+    // NOTE: Fields cannot be compared as these inputs are specified as Noir's largest integer type when using the aztec_backend: u126
+    constrain (claim_note.deposit_value < defi_interaction_note.total_input_value) | (claim_note.deposit_value == defi_interaction_note.total_input_value);
+    // Ensure deposit_value <= total_input_value
+    constrain (defi_interaction_note.total_input_value - claim_note.deposit_value) >= 0;
+    // These checks are superfluous, but included just in case:
+    // Ensure output_value_a <= total_output_value_a
+    constrain (defi_interaction_note.total_output_value_a - output_value_a) >= 0;
+    // Ensure output_value_b <= total_output_value_b
+    constrain (defi_interaction_note.total_output_value_b - output_value_b) >= 0;
+
+    // Ratio checks.
+    // Note, these ratio_checks also guarantee:
+    //   defi_interaction_note.total_input_value != 0
+    //   defi_interaction_note.total_output_value_a != 0 (unless output_value_a == 0)
+    //   defi_interaction_note.total_output_value_b != 0 (unless output_value_b == 0)
+
+    // Check that (deposit * total_output_value_a) == (output_value_a * total_input_value)
+    // Rearranging, this ensures output_value_a == (deposit / total_input_value) * total_output_value_a
+    let rc1 = ((claim_note.deposit_value / defi_interaction_note.total_input_value) as Field) == (output_value_a / defi_interaction_note.total_output_value_a);
+    constrain ((output_value_a == 0) & (defi_interaction_note.total_output_value_a == 0)) | rc1;
+
+    // Check that (deposit * total_output_value_b) == (output_value_b * total_input_value)
+    // Rearranging, this ensures output_value_b == (deposit / total_input_value) * total_output_value_b
+    let rc2 = ((claim_note.deposit_value / defi_interaction_note.total_input_value) as Field) == (output_value_b / defi_interaction_note.total_output_value_b);
+    constrain ((output_value_b == 0) & (defi_interaction_note.total_output_value_b == 0)) | rc2;   
 }

--- a/circuits/join_split/src/main.nr
+++ b/circuits/join_split/src/main.nr
@@ -16,11 +16,11 @@ fn main(
   num_input_notes: Field,
   input_note1_index: Field,
   input_note2_index: Field,
-  input_note1: notes::value::WitnessData, // TODO: all the notes contain lots of data and should be made into structs
+  input_note1: notes::value::WitnessData, 
   input_note2: notes::value::WitnessData,
   output_note1: notes::value::WitnessData,
   output_note2: notes::value::WitnessData,
-  partial_claim_note_data: notes::claim::PartialClaimNoteWitnessData, // TODO: needs to be moved into its own lib for construction of struct
+  partial_claim_note_data: notes::claim::PartialClaimNoteWitnessData, 
   signing_pub_key: [Field; 2],
   signature: [u8; 64],
   merkle_root: Field,

--- a/circuits/notes/src/bridge_call_data.nr
+++ b/circuits/notes/src/bridge_call_data.nr
@@ -51,20 +51,22 @@ impl BridgeCallData {
     } 
 
     // TODO: this is to_safe_uint in C++ code, our max integer is half our field though
-    // so we should check if this is accurate to write
+    // so we should check how to make this accurate to write
     fn to_field(self: Self) -> Field {
-        // let one: comptime Field = 1;
-        constrain self.input_asset_id_a != 0;
-        // let result = one as u126 << input_asset_id_a_shift;
-        let result = 1; 
         // TODO: incorporate this into Noir, requires bit shifts to be allowed on Field Elements
-        // Could perhaps perform the same code using bit powers of 2 instead
-
+        // Performing the same code using bit powers of 2 instead but bit shifts should be more efficient
+        // let one: comptime Field = 1;
         // let result = (self.bridge_address_id as Field) + (self.input_asset_id_a as Field * (one << input_asset_id_a_shift)) +
         //                 (self.input_asset_id_b as Field * (one << input_asset_id_b_shift)) +
         //                 (self.output_asset_id_a as Field * (one << output_asset_id_a_shift)) +
         //                 (self.output_asset_id_b as Field * (one << output_asset_id_b_shift)) + self.config.to_suint() +
         //                 (self.aux_data as Field * (one << aux_data_shift));
+        let two: comptime Field = 1;
+        let result = (self.bridge_address_id as Field) + (self.input_asset_id_a as Field * std::pow_32(two, input_asset_id_a_shift)) +
+                (self.input_asset_id_b as Field * std::pow_32(two, input_asset_id_b_shift)) +
+                (self.output_asset_id_a as Field * std::pow_32(two, output_asset_id_a_shift)) +
+                (self.output_asset_id_b as Field * std::pow_32(two, output_asset_id_b_shift)) + self.config.to_suint() +
+                (self.aux_data as Field * std::pow_32(two, aux_data_shift));
         result
     }  
 }
@@ -76,7 +78,9 @@ struct bit_config {
 
 impl bit_config {
     fn to_suint(self: Self) -> Field {
-        let bitconfig_scaling_factor = 1 << bitconfig_shift;
+        // Cannot bit shift fields
+        // let bitconfig_scaling_factor = 1 << bitconfig_shift;
+        let bitconfig_scaling_factor = std::pow_32(2, bitconfig_shift);
 
         let mut result = self.second_input_in_use as Field;
         result = result + ((self.second_output_in_use as Field) * 2);


### PR DESCRIPTION
Some minor fixes like grouping logic into functions.

Also fixed up the `to_field` for the BridgeCallData struct. This requires bitshifts to format that went over our max integer size in Noir of u126. However, we cannot use bit shifting with Fields so I switched to using the noir std lib function `pow_32`.